### PR TITLE
add commands support

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -98,6 +98,10 @@ func (c *ChatViewController) Select(contact Contact) error {
 
 	go c.readMessagesLoop(sub, messages, c.cancel, c.done)
 
+	return c.RequestMessages()
+}
+
+func (c *ChatViewController) RequestMessages() error {
 	// Request some previous messages from the current chat
 	// to provide some context for the user.
 	// TODO: handle pagination
@@ -110,7 +114,7 @@ func (c *ChatViewController) Select(contact Contact) error {
 		Limit: 1000,
 	}
 
-	switch contact.Type {
+	switch c.currentContact.Type {
 	case ContactPublicChat:
 		if err := c.chat.RequestPublicMessages(ctx, c.currentContact.Name, params); err != nil {
 			return fmt.Errorf("failed to request public messages: %v", err)
@@ -119,6 +123,8 @@ func (c *ChatViewController) Select(contact Contact) error {
 		if err := c.chat.RequestPrivateMessages(ctx, params); err != nil {
 			return fmt.Errorf("failed to request private messages: %v", err)
 		}
+	default:
+		return errors.New("invalid contact type")
 	}
 
 	return nil

--- a/contacts.go
+++ b/contacts.go
@@ -90,3 +90,7 @@ func (c *ContactsViewController) Refresh() {
 		return nil
 	})
 }
+
+func (c *ContactsViewController) Add(contact Contact) {
+	c.items = append(c.items, contact)
+}

--- a/input.go
+++ b/input.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"strings"
+
+	"github.com/jroimartin/gocui"
+)
+
+const DefaultMultiplexerPrefix = "default"
+
+type InputMultiplexer struct {
+	handlers map[string]func([]byte) error // map string prefix to handler
+}
+
+func NewInputMultiplexer() *InputMultiplexer {
+	return &InputMultiplexer{
+		handlers: make(map[string]func([]byte) error),
+	}
+}
+
+func (m *InputMultiplexer) BindingHandler(g *gocui.Gui, v *gocui.View) error {
+	if v == nil {
+		return nil
+	}
+
+	var buf bytes.Buffer
+	if err := EnterHandler(&buf)(g, v); err != nil {
+		return err
+	}
+
+	inputStr := buf.String()
+	inputBytes := bytes.TrimSpace(buf.Bytes())
+
+	for prefix, h := range m.handlers {
+		if strings.HasPrefix(inputStr, prefix) {
+			return h(inputBytes)
+		}
+	}
+
+	if h, ok := m.handlers[DefaultMultiplexerPrefix]; ok {
+		return h(inputBytes)
+	}
+
+	return nil
+}
+
+func (m *InputMultiplexer) AddHandler(prefix string, h func([]byte) error) {
+	m.handlers[prefix] = h
+}
+
+func bytesToArgs(b []byte) []string {
+	args := bytes.Split(b, []byte(" "))
+	argsStr := make([]string, len(args))
+	for i, arg := range args {
+		argsStr[i] = string(arg)
+	}
+	return argsStr
+}
+
+// ContactCmdHandler handles /contact command.
+//
+// Usage:
+//   * /contact add public-chat-name
+//   * /contact add 0xabc name
+func ContactCmdHandler(b []byte) (c Contact, err error) {
+	args := bytesToArgs(b)[1:] // remove first item, i.e. "/contact"
+
+	log.Printf("ContactCmdHandler arguments: %s", args)
+
+	switch args[0] {
+	case "add":
+		if len(args[1:]) == 1 {
+			c = Contact{Name: args[1], Type: ContactPublicChat}
+		} else if len(args[1:]) == 2 {
+			c, err = NewContactWithPublicKey(args[2], args[1])
+		} else {
+			err = errors.New("/contact cmd: incorect arguments to add subcommand")
+		}
+		return
+	default:
+		err = errors.New("/contact cmd: invalid subcommand")
+	}
+
+	return
+}
+
+func RequestCmdHandler(b []byte) error {
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -16,10 +16,10 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/jroimartin/gocui"
 	"github.com/peterbourgon/ff"
+	"github.com/status-im/status-console-client/protocol/v1"
 	"github.com/status-im/status-go/node"
 	"github.com/status-im/status-go/params"
 	"github.com/status-im/status-go/signal"
-	"github.com/status-im/status-console-client/protocol/v1"
 )
 
 var g *gocui.Gui
@@ -149,6 +149,32 @@ func main() {
 		},
 	)
 
+	inputMultiplexer := NewInputMultiplexer()
+	inputMultiplexer.AddHandler(DefaultMultiplexerPrefix, func(b []byte) error {
+		log.Printf("default multiplexer handler")
+		_, err := chat.SendMessage(b)
+		return err
+	})
+	inputMultiplexer.AddHandler("/contact", func(b []byte) error {
+		log.Printf("handle /contact command: %s", b)
+
+		contact, err := ContactCmdHandler(b)
+		if err != nil {
+			return err
+		}
+
+		log.Printf("adding contact: %+v", contact)
+
+		contacts.Add(contact)
+		contacts.Refresh()
+
+		return nil
+	})
+	inputMultiplexer.AddHandler("/request", func(b []byte) error {
+		log.Printf("handle /request command: %s", b)
+		return chat.RequestMessages()
+	})
+
 	views := []*View{
 		&View{
 			Name:       ViewContacts,
@@ -232,7 +258,7 @@ func main() {
 				Binding{
 					Key:     gocui.KeyEnter,
 					Mod:     gocui.ModNone,
-					Handler: EnterInputHandler(chat),
+					Handler: inputMultiplexer.BindingHandler,
 				},
 				Binding{
 					Key:     gocui.KeyEnter,


### PR DESCRIPTION
This PR implements basic commands support in the Input view.

Two commands are implemented as an example:
- `/contact`,
- `/request`.