### PR TITLE
add geth service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,11 @@ matrix:
     env: GOFLAGS=-mod=vendor
     script:
     - make lint
-    - make test
+    # fails without -a
+    - go test -a ./... # make test
   - go: "1.12.x"
     env: GOFLAGS=-mod=vendor
     script:
     - make lint
-    - make test
+    # fails without -a
+    - go test -a ./... # make test

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ run: build
 .PHONY: run
 
 test:
-	go test -a ./...
+	go test ./...
 .PHONY: test
 
 test-race:

--- a/chat_test.go
+++ b/chat_test.go
@@ -71,7 +71,7 @@ func TestSendMessage(t *testing.T) {
 	require.NoError(t, err)
 	require.EqualValues(t, payload, statusMessage.Text)
 	require.Equal(t, protocol.ContentTypeTextPlain, statusMessage.ContentT)
-	require.Equal(t, protocol.MessageTypePublicGroupUserMessage, statusMessage.MessageT)
+	require.Equal(t, protocol.MessageTypePublicGroup, statusMessage.MessageT)
 	require.Equal(t,
 		protocol.StatusMessageContent{ChatID: chatName, Text: string(payload)},
 		statusMessage.Content)

--- a/main.go
+++ b/main.go
@@ -154,7 +154,7 @@ func main() {
 				exitErr(errors.Wrap(err, "failed to create databases dir"))
 			}
 
-			if err := adapter.InitPFS(databasesDir, privateKey); err != nil {
+			if err := adapter.InitPFS(databasesDir); err != nil {
 				exitErr(errors.Wrap(err, "initialize PFS"))
 			}
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ var (
 	keyHex = fs.String("keyhex", "", "pass a private key in hex")
 )
 
-func init() {
+func main() {
 	log.SetOutput(os.Stderr)
 
 	if err := ff.Parse(fs, os.Args[1:]); err != nil {
@@ -58,9 +58,7 @@ func init() {
 	if err != nil {
 		log.Fatalf("failed to override root log: %v\n", err)
 	}
-}
 
-func main() {
 	if *createKeyPair {
 		key, err := crypto.GenerateKey()
 		if err != nil {
@@ -163,8 +161,6 @@ func main() {
 
 		proto = adapter
 	}
-
-	var err error
 
 	g, err = gocui.NewGui(gocui.Output256)
 	if err != nil {

--- a/node_config.go
+++ b/node_config.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	if err := logutils.OverrideRootLog(true, "INFO", logutils.FileOptions{}, false); err != nil {
+	if err := logutils.OverrideRootLog(true, "DEBUG", logutils.FileOptions{}, false); err != nil {
 		stdlog.Fatalf("failed to override root log: %v\n", err)
 	}
 }
@@ -25,10 +25,17 @@ func generateStatusNodeConfig(dataDir, fleet, configFile string) (*params.NodeCo
 		configFiles = append(configFiles, configFile)
 	}
 
-	return params.NewNodeConfigWithDefaultsAndFiles(
+	config, err := params.NewNodeConfigWithDefaultsAndFiles(
 		dataDir,
 		params.MainNetworkID,
 		[]params.Option{params.WithFleet(fleet)},
 		configFiles,
 	)
+	if err != nil {
+		return nil, err
+	}
+
+	config.IPCEnabled = true
+
+	return config, nil
 }

--- a/node_config.go
+++ b/node_config.go
@@ -2,18 +2,10 @@ package main
 
 import (
 	"fmt"
-	stdlog "log"
 	"os"
 
-	"github.com/status-im/status-go/logutils"
 	"github.com/status-im/status-go/params"
 )
-
-func init() {
-	if err := logutils.OverrideRootLog(true, "DEBUG", logutils.FileOptions{}, false); err != nil {
-		stdlog.Fatalf("failed to override root log: %v\n", err)
-	}
-}
 
 func generateStatusNodeConfig(dataDir, fleet, configFile string) (*params.NodeConfig, error) {
 	if err := os.MkdirAll(dataDir, os.ModeDir|0755); err != nil {

--- a/protocol/adapters/whisper.go
+++ b/protocol/adapters/whisper.go
@@ -3,6 +3,7 @@ package adapters
 import "crypto/ecdsa"
 
 type keysManager interface {
+	PrivateKey() *ecdsa.PrivateKey
 	AddOrGetKeyPair(priv *ecdsa.PrivateKey) (string, error)
 	AddOrGetSymKeyFromPassword(password string) (string, error)
 	GetRawSymKey(string) ([]byte, error)

--- a/protocol/adapters/whisper_client.go
+++ b/protocol/adapters/whisper_client.go
@@ -250,7 +250,7 @@ type criteria struct {
 func newCriteria(keys keysManager) *criteria {
 	return &criteria{
 		Criteria: whisper.Criteria{
-			MinPow:   0,    // TODO: set it to proper value
+			MinPow:   WhisperPoW,
 			AllowP2P: true, // messages from mail server are direct p2p messages
 		},
 		keys: keys,

--- a/protocol/adapters/whisper_service.go
+++ b/protocol/adapters/whisper_service.go
@@ -161,8 +161,7 @@ func (a *WhisperServiceAdapter) Subscribe(
 			case <-t.C:
 				received, err := subWhisper.Messages()
 				if err != nil {
-					// TODO: handle err
-					sub.Unsubscribe()
+					sub.Cancel(err)
 					return
 				}
 

--- a/protocol/adapters/whisper_service.go
+++ b/protocol/adapters/whisper_service.go
@@ -91,7 +91,7 @@ func NewWhisperServiceAdapter(node *node.StatusNode, shh *whisper.Whisper, priva
 }
 
 // InitPFS adds support for PFS messages.
-func (a *WhisperServiceAdapter) InitPFS(baseDir string, privateKey *ecdsa.PrivateKey) error {
+func (a *WhisperServiceAdapter) InitPFS(baseDir string) error {
 	addBundlesHandler := func(addedBundles []chat.IdentityAndIDPair) {
 		log.Printf("added bundles: %v", addedBundles)
 	}
@@ -117,21 +117,14 @@ func (a *WhisperServiceAdapter) InitPFS(baseDir string, privateKey *ecdsa.Privat
 		addBundlesHandler,
 	)
 
-	return a.SetPFS(pfs, privateKey)
+	a.SetPFS(pfs)
+
+	return nil
 }
 
 // SetPFS sets the PFS service and a private key.
-func (a *WhisperServiceAdapter) SetPFS(pfs *chat.ProtocolService, privateKey *ecdsa.PrivateKey) error {
-	pk := a.keysManager.PrivateKey()
-
-	// verify the same private key is used
-	if pk == nil || privateKey.X.Cmp(pk.X) != 0 || privateKey.Y.Cmp(pk.Y) != 0 {
-		return errors.New("provided PFS private key is different from the currently set")
-	}
-
+func (a *WhisperServiceAdapter) SetPFS(pfs *chat.ProtocolService) {
 	a.pfs = pfs
-
-	return nil
 }
 
 // Subscribe subscribes to a public chat using the Whisper service.

--- a/protocol/adapters/whisper_service.go
+++ b/protocol/adapters/whisper_service.go
@@ -22,8 +22,17 @@ import (
 type whisperServiceKeysManager struct {
 	shh *whisper.Whisper
 
+	// Identity of the current user.
+	// It must be the same private key
+	// that is used in the PFS service.
+	privateKey *ecdsa.PrivateKey
+
 	passToSymKeyMutex sync.RWMutex
 	passToSymKeyCache map[string]string
+}
+
+func (m *whisperServiceKeysManager) PrivateKey() *ecdsa.PrivateKey {
+	return m.privateKey
 }
 
 func (m *whisperServiceKeysManager) AddOrGetKeyPair(priv *ecdsa.PrivateKey) (string, error) {
@@ -56,14 +65,11 @@ func (m *whisperServiceKeysManager) GetRawSymKey(id string) ([]byte, error) {
 // WhisperServiceAdapter is an adapter for Whisper service
 // the implements Protocol interface.
 type WhisperServiceAdapter struct {
-	node        *node.StatusNode
+	node        *node.StatusNode // TODO: replace with an interface
 	shh         *whisper.Whisper
 	keysManager *whisperServiceKeysManager
 
-	// PFS supports only one private key which should be provided
-	// during PFS initialization.
-	pfsPrivateKey *ecdsa.PrivateKey
-	pfs           *chat.ProtocolService
+	pfs *chat.ProtocolService
 
 	selectedMailServerEnode string
 }
@@ -72,12 +78,13 @@ type WhisperServiceAdapter struct {
 var _ protocol.Protocol = (*WhisperServiceAdapter)(nil)
 
 // NewWhisperServiceAdapter returns a new WhisperServiceAdapter.
-func NewWhisperServiceAdapter(node *node.StatusNode, shh *whisper.Whisper) *WhisperServiceAdapter {
+func NewWhisperServiceAdapter(node *node.StatusNode, shh *whisper.Whisper, privateKey *ecdsa.PrivateKey) *WhisperServiceAdapter {
 	return &WhisperServiceAdapter{
 		node: node,
 		shh:  shh,
 		keysManager: &whisperServiceKeysManager{
 			shh:               shh,
+			privateKey:        privateKey,
 			passToSymKeyCache: make(map[string]string),
 		},
 	}
@@ -102,14 +109,27 @@ func (a *WhisperServiceAdapter) InitPFS(baseDir string, privateKey *ecdsa.Privat
 		return err
 	}
 
-	a.pfsPrivateKey = privateKey
-	a.pfs = chat.NewProtocolService(
+	pfs := chat.NewProtocolService(
 		chat.NewEncryptionService(
 			persistence,
 			chat.DefaultEncryptionServiceConfig(instalationID),
 		),
 		addBundlesHandler,
 	)
+
+	return a.SetPFS(pfs, privateKey)
+}
+
+// SetPFS sets the PFS service and a private key.
+func (a *WhisperServiceAdapter) SetPFS(pfs *chat.ProtocolService, privateKey *ecdsa.PrivateKey) error {
+	pk := a.keysManager.PrivateKey()
+
+	// verify the same private key is used
+	if pk == nil || privateKey.X.Cmp(pk.X) != 0 || privateKey.Y.Cmp(pk.Y) != 0 {
+		return errors.New("provided PFS private key is different from the currently set")
+	}
+
+	a.pfs = pfs
 
 	return nil
 }
@@ -124,17 +144,17 @@ func (a *WhisperServiceAdapter) Subscribe(
 		return nil, err
 	}
 
-	filter, err := createRichFilter(a.keysManager, options)
+	filter := newFilter(a.keysManager)
+	if err := updateFilterFromSubscribeOptions(filter, options); err != nil {
+		return nil, err
+	}
+
+	filterID, err := a.shh.Subscribe(filter.ToWhisper())
 	if err != nil {
 		return nil, err
 	}
 
-	filterID, err := a.shh.Subscribe(filter)
-	if err != nil {
-		return nil, err
-	}
-
-	subWhisper := newWhisperSubscription(a.shh, a.pfs, a.pfsPrivateKey, filterID)
+	subWhisper := newWhisperSubscription(a.shh, filterID)
 	sub := protocol.NewSubscription()
 
 	go func() {
@@ -148,7 +168,8 @@ func (a *WhisperServiceAdapter) Subscribe(
 			case <-t.C:
 				received, err := subWhisper.Messages()
 				if err != nil {
-					sub.Cancel(err)
+					// TODO: handle err
+					sub.Unsubscribe()
 					return
 				}
 
@@ -190,7 +211,12 @@ func (a *WhisperServiceAdapter) decodeMessage(message *whisper.ReceivedMessage) 
 	hash := message.EnvelopeHash.Bytes()
 
 	if a.pfs != nil {
-		decryptedPayload, err := a.pfs.HandleMessage(a.pfsPrivateKey, publicKey, payload, hash)
+		decryptedPayload, err := a.pfs.HandleMessage(
+			a.keysManager.PrivateKey(),
+			publicKey,
+			payload,
+			hash,
+		)
 		if err != nil {
 			log.Printf("failed to handle message %#+x by PFS: %v", hash, err)
 		} else {
@@ -221,21 +247,28 @@ func (a *WhisperServiceAdapter) Send(
 	}
 
 	if a.pfs != nil {
-		encryptedPayload, err := a.pfs.BuildDirectMessage(a.pfsPrivateKey, options.Recipient, data)
+		encryptedPayload, err := a.pfs.BuildDirectMessage(
+			a.keysManager.PrivateKey(),
+			options.Recipient,
+			data,
+		)
 		if err != nil {
 			return nil, err
 		}
 		data = encryptedPayload
 	}
 
-	message, err := createRichWhisperNewMessage(a.keysManager, data, options)
+	newMessage, err := newNewMessage(a.keysManager, data)
 	if err != nil {
+		return nil, err
+	}
+	if err := updateNewMessageFromSendOptions(newMessage, options); err != nil {
 		return nil, err
 	}
 
 	// Only public Whisper API implements logic to send messages.
 	shhAPI := whisper.NewPublicWhisperAPI(a.shh)
-	return shhAPI.Post(ctx, message)
+	return shhAPI.Post(ctx, newMessage.ToWhisper())
 }
 
 // Request requests messages from mail servers.
@@ -332,19 +365,15 @@ func (a *WhisperServiceAdapter) requestMessages(ctx context.Context, req shhext.
 
 // whisperSubscription encapsulates a Whisper filter.
 type whisperSubscription struct {
-	shh          *whisper.Whisper
-	pfs          *chat.ProtocolService
-	myPrivateKey *ecdsa.PrivateKey
-	filterID     string
+	shh      *whisper.Whisper
+	filterID string
 }
 
 // newWhisperSubscription returns a new whisperSubscription.
-func newWhisperSubscription(shh *whisper.Whisper, pfs *chat.ProtocolService, pk *ecdsa.PrivateKey, filterID string) *whisperSubscription {
+func newWhisperSubscription(shh *whisper.Whisper, filterID string) *whisperSubscription {
 	return &whisperSubscription{
-		shh:          shh,
-		pfs:          pfs,
-		myPrivateKey: pk,
-		filterID:     filterID,
+		shh:      shh,
+		filterID: filterID,
 	}
 }
 
@@ -363,33 +392,63 @@ func (s whisperSubscription) Unsubscribe() error {
 	return s.shh.Unsubscribe(s.filterID)
 }
 
-func createRichFilter(keys keysManager, options protocol.SubscribeOptions) (*whisper.Filter, error) {
-	filter := whisper.Filter{
-		PoW:      0,
-		AllowP2P: true,
-	}
+type filter struct {
+	*whisper.Filter
+	keys keysManager
+}
 
-	topic, err := topicForSubscribeOptions(options)
+func newFilter(keys keysManager) *filter {
+	return &filter{
+		Filter: &whisper.Filter{
+			PoW:      0,
+			AllowP2P: true,
+		},
+		keys: keys,
+	}
+}
+
+func (f *filter) ToWhisper() *whisper.Filter {
+	return f.Filter
+}
+
+func (f *filter) updateForPublicGroup(name string) error {
+	topic, err := PublicChatTopic(name)
 	if err != nil {
-		return nil, err
+		return err
 	}
-	filter.Topics = append(filter.Topics, topic[:])
+	f.Topics = append(f.Topics, topic[:])
 
-	if options.Identity != nil {
-		filter.KeyAsym = options.Identity
+	symKeyID, err := f.keys.AddOrGetSymKeyFromPassword(name)
+	if err != nil {
+		return err
 	}
-
-	if options.ChatName != "" {
-		symKeyID, err := keys.AddOrGetSymKeyFromPassword(options.ChatName)
-		if err != nil {
-			return nil, err
-		}
-		symKey, err := keys.GetRawSymKey(symKeyID)
-		if err != nil {
-			return nil, err
-		}
-		filter.KeySym = symKey
+	symKey, err := f.keys.GetRawSymKey(symKeyID)
+	if err != nil {
+		return err
 	}
+	f.KeySym = symKey
 
-	return &filter, nil
+	return nil
+}
+
+func (f *filter) updateForPrivate(recipient *ecdsa.PublicKey) error {
+	topic, err := PrivateChatTopic()
+	if err != nil {
+		return err
+	}
+	f.Topics = append(f.Topics, topic[:])
+
+	f.KeyAsym = f.keys.PrivateKey()
+
+	return nil
+}
+
+func updateFilterFromSubscribeOptions(f *filter, options protocol.SubscribeOptions) error {
+	if options.Recipient != nil {
+		return f.updateForPrivate(options.Recipient)
+	} else if options.ChatName != "" {
+		return f.updateForPublicGroup(options.ChatName)
+	} else {
+		return errors.New("unrecognized options")
+	}
 }

--- a/protocol/adapters/whisper_topic.go
+++ b/protocol/adapters/whisper_topic.go
@@ -36,7 +36,7 @@ func topicForSendOptions(options protocol.SendOptions) (whisper.TopicType, error
 }
 
 func topicForSubscribeOptions(options protocol.SubscribeOptions) (whisper.TopicType, error) {
-	if options.Identity != nil {
+	if options.Recipient != nil {
 		return PrivateChatTopic()
 	}
 

--- a/protocol/adapters/whisper_topic.go
+++ b/protocol/adapters/whisper_topic.go
@@ -23,30 +23,6 @@ func PrivateChatTopic() (whisper.TopicType, error) {
 	return PublicChatTopic(TopicDiscovery)
 }
 
-func topicForSendOptions(options protocol.SendOptions) (whisper.TopicType, error) {
-	if options.Recipient != nil {
-		return PrivateChatTopic()
-	}
-
-	if options.ChatName != "" {
-		return PublicChatTopic(options.ChatName)
-	}
-
-	return whisper.TopicType{}, errors.New("invalid options")
-}
-
-func topicForSubscribeOptions(options protocol.SubscribeOptions) (whisper.TopicType, error) {
-	if options.Recipient != nil {
-		return PrivateChatTopic()
-	}
-
-	if options.ChatName != "" {
-		return PublicChatTopic(options.ChatName)
-	}
-
-	return whisper.TopicType{}, errors.New("invalid options")
-}
-
 func topicForRequestOptions(options protocol.RequestOptions) (whisper.TopicType, error) {
 	if options.Recipient != nil {
 		return PrivateChatTopic()

--- a/protocol/client/chat.go
+++ b/protocol/client/chat.go
@@ -213,7 +213,7 @@ func (c *Chat) Send(data []byte) error {
 	c.updateLastClock(message.Clock)
 	c.Unlock()
 
-	opts, err := extendSendOptions(protocol.SendOptions{Identity: c.identity}, c)
+	opts, err := extendSendOptions(protocol.SendOptions{}, c)
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare send options")
 	}

--- a/protocol/client/chat.go
+++ b/protocol/client/chat.go
@@ -115,7 +115,7 @@ func (c *Chat) Subscribe(params protocol.RequestOptions) (err error) {
 		return errors.New("already subscribed")
 	}
 
-	opts, err := extendSubscribeOptions(protocol.SubscribeOptions{}, c)
+	opts, err := createSubscribeOptions(c.contact)
 	if err != nil {
 		return errors.Wrap(err, "failed to subscribe")
 	}
@@ -165,7 +165,7 @@ func (c *Chat) load(options protocol.RequestOptions) error {
 }
 
 func (c *Chat) request(options protocol.RequestOptions) error {
-	opts, err := extendRequestOptions(options, c)
+	opts, err := createRequestOptions(c.contact)
 	if err != nil {
 		return err
 	}
@@ -213,7 +213,7 @@ func (c *Chat) Send(data []byte) error {
 	c.updateLastClock(message.Clock)
 	c.Unlock()
 
-	opts, err := extendSendOptions(protocol.SendOptions{}, c)
+	opts, err := createSendOptions(c.contact)
 	if err != nil {
 		return errors.Wrap(err, "failed to prepare send options")
 	}
@@ -224,6 +224,7 @@ func (c *Chat) Send(data []byte) error {
 	if c.contact.Type == ContactPrivateChat {
 		log.Printf("[Chat::Send] sent a private message")
 
+		// TODO: this should be created by c.proto
 		c.ownMessages <- &protocol.Message{
 			Decoded:   message,
 			SigPubKey: &c.identity.PublicKey,

--- a/protocol/client/chat_options.go
+++ b/protocol/client/chat_options.go
@@ -15,7 +15,7 @@ func extendSubscribeOptions(opts protocol.SubscribeOptions, c *Chat) (protocol.S
 	case ContactPublicChat:
 		opts.ChatName = c.contact.Name
 	case ContactPrivateChat:
-		opts.Identity = c.identity
+		opts.Recipient = c.contact.PublicKey
 	default:
 		return opts, errUnsupportedContactType
 	}

--- a/protocol/client/chat_options.go
+++ b/protocol/client/chat_options.go
@@ -10,38 +10,38 @@ var (
 	errUnsupportedContactType = fmt.Errorf("unsupported contact type")
 )
 
-func extendSubscribeOptions(opts protocol.SubscribeOptions, c *Chat) (protocol.SubscribeOptions, error) {
-	switch c.contact.Type {
+func createSubscribeOptions(c Contact) (opts protocol.SubscribeOptions, err error) {
+	switch c.Type {
 	case ContactPublicChat:
-		opts.ChatName = c.contact.Name
+		opts.ChatName = c.Name
 	case ContactPrivateChat:
-		opts.Recipient = c.contact.PublicKey
+		opts.Recipient = c.PublicKey
 	default:
-		return opts, errUnsupportedContactType
+		err = errUnsupportedContactType
 	}
-	return opts, nil
+	return
 }
 
-func extendRequestOptions(opts protocol.RequestOptions, c *Chat) (protocol.RequestOptions, error) {
-	switch c.contact.Type {
+func createRequestOptions(c Contact) (opts protocol.RequestOptions, err error) {
+	switch c.Type {
 	case ContactPublicChat:
-		opts.ChatName = c.contact.Name
+		opts.ChatName = c.Name
 	case ContactPrivateChat:
-		opts.Recipient = c.contact.PublicKey
+		opts.Recipient = c.PublicKey
 	default:
-		return opts, errUnsupportedContactType
+		err = errUnsupportedContactType
 	}
-	return opts, nil
+	return
 }
 
-func extendSendOptions(opts protocol.SendOptions, c *Chat) (protocol.SendOptions, error) {
-	switch c.contact.Type {
+func createSendOptions(c Contact) (opts protocol.SendOptions, err error) {
+	switch c.Type {
 	case ContactPublicChat:
-		opts.ChatName = c.contact.Name
+		opts.ChatName = c.Name
 	case ContactPrivateChat:
-		opts.Recipient = c.contact.PublicKey
+		opts.Recipient = c.PublicKey
 	default:
-		return opts, errUnsupportedContactType
+		err = errUnsupportedContactType
 	}
-	return opts, nil
+	return
 }

--- a/protocol/client/chat_test.go
+++ b/protocol/client/chat_test.go
@@ -121,7 +121,7 @@ func TestHandleMessageFromProtocol(t *testing.T) {
 		Decoded: protocol.StatusMessage{
 			Text:      "some",
 			ContentT:  protocol.ContentTypeTextPlain,
-			MessageT:  protocol.MessageTypePublicGroupUserMessage,
+			MessageT:  protocol.MessageTypePublicGroup,
 			Timestamp: now * 1000,
 			Clock:     now * 1000,
 		},

--- a/protocol/gethservice/api.go
+++ b/protocol/gethservice/api.go
@@ -26,7 +26,7 @@ func (api *PublicAPI) Messages(ctx context.Context, params SubscribeParams) (*rp
 	}
 
 	adapterOptions := protocol.SubscribeOptions{
-		ChatName: params.PubChatName,
+		ChatName: params.PubChatName, // no transformation required
 	}
 
 	if len(params.RecipientPubKey) > 0 {
@@ -34,7 +34,6 @@ func (api *PublicAPI) Messages(ctx context.Context, params SubscribeParams) (*rp
 		if err != nil {
 			return nil, err
 		}
-
 		adapterOptions.Recipient = publicKey
 	}
 
@@ -91,7 +90,6 @@ func (api *PublicAPI) Send(ctx context.Context, data hexutil.Bytes, params SendP
 		if err != nil {
 			return nil, err
 		}
-
 		adapterOptions.Recipient = publicKey
 	}
 

--- a/protocol/gethservice/api.go
+++ b/protocol/gethservice/api.go
@@ -1,0 +1,100 @@
+package gethservice
+
+import (
+	"context"
+	"log"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/status-im/status-console-client/protocol/v1"
+)
+
+type PublicAPI struct {
+	service *Service
+}
+
+type SubscribeParams struct {
+	RecipientPubKey hexutil.Bytes `json:"recipientPubKey"` // public key hex-encoded
+	PubChatName     string        `json:"pubChatName"`
+}
+
+func (api *PublicAPI) Messages(ctx context.Context, params SubscribeParams) (*rpc.Subscription, error) {
+	notifier, supported := rpc.NotifierFromContext(ctx)
+	if !supported {
+		return nil, rpc.ErrNotificationsUnsupported
+	}
+
+	adapterOptions := protocol.SubscribeOptions{
+		ChatName: params.PubChatName,
+	}
+
+	if len(params.RecipientPubKey) > 0 {
+		publicKey, err := crypto.UnmarshalPubkey(params.RecipientPubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		adapterOptions.Recipient = publicKey
+	}
+
+	messages := make(chan *protocol.Message, 100)
+	sub, err := api.service.protocol.Subscribe(ctx, messages, adapterOptions)
+	if err != nil {
+		log.Printf("failed to subscribe to the protocol: %v", err)
+		return nil, err
+	}
+
+	rpcSub := notifier.CreateSubscription()
+
+	go func() {
+		defer sub.Unsubscribe()
+
+		for {
+			select {
+			case m := <-messages:
+				if err := notifier.Notify(rpcSub.ID, m.Decoded); err != nil {
+					log.Printf("failed to notify %s about new message", rpcSub.ID)
+				}
+			case <-sub.Done():
+				if err := sub.Err(); err != nil {
+					log.Printf("subscription to adapter errored: %v", err)
+				}
+				return
+			case err := <-rpcSub.Err():
+				if err != nil {
+					log.Printf("RPC subscription errored: %v", err)
+				}
+				return
+			case <-notifier.Closed():
+				log.Printf("notifier closed")
+				return
+			}
+		}
+	}()
+
+	return rpcSub, nil
+}
+
+type SendParams struct {
+	RecipientPubKey hexutil.Bytes `json:"recipientPubKey"` // public key hex-encoded
+	PubChatName     string        `json:"pubChatName"`
+}
+
+func (api *PublicAPI) Send(ctx context.Context, data hexutil.Bytes, params SendParams) (hexutil.Bytes, error) {
+	adapterOptions := protocol.SendOptions{
+		ChatName: params.PubChatName, // no transformation required
+	}
+
+	if len(params.RecipientPubKey) > 0 {
+		publicKey, err := crypto.UnmarshalPubkey(params.RecipientPubKey)
+		if err != nil {
+			return nil, err
+		}
+
+		adapterOptions.Recipient = publicKey
+	}
+
+	hash, err := api.service.protocol.Send(ctx, data, adapterOptions)
+	return hexutil.Bytes(hash), err
+}

--- a/protocol/gethservice/service.go
+++ b/protocol/gethservice/service.go
@@ -14,16 +14,20 @@ import (
 
 var _ gethnode.Service = (*Service)(nil)
 
+// KeysGetter is an interface that specifies what kind of keys
+// should an implementation provide.
 type KeysGetter interface {
 	PrivateKey() (*ecdsa.PrivateKey, error)
 }
 
+// Service is a wrapper around Protocol.
 type Service struct {
 	node     *node.StatusNode
 	keys     KeysGetter
 	protocol protocol.Protocol
 }
 
+// New creates a new Service.
 func New(node *node.StatusNode, keys KeysGetter) *Service {
 	return &Service{
 		node: node,
@@ -31,17 +35,19 @@ func New(node *node.StatusNode, keys KeysGetter) *Service {
 	}
 }
 
+// SetProtocol sets a given Protocol implementation.
 func (s *Service) SetProtocol(proto protocol.Protocol) {
 	s.protocol = proto
 }
 
 // gethnode.Service interface implementation
 
+// Protocols list a list of p2p protocols defined by this service.s
 func (s *Service) Protocols() []p2p.Protocol {
 	return nil
 }
 
-// APIs retrieves the list of RPC descriptors the service provides
+// APIs retrieves the list of RPC descriptors the service provides.
 func (s *Service) APIs() []rpc.API {
 	return []rpc.API{
 		{

--- a/protocol/gethservice/service.go
+++ b/protocol/gethservice/service.go
@@ -1,0 +1,66 @@
+package gethservice
+
+import (
+	"crypto/ecdsa"
+
+	"github.com/status-im/status-console-client/protocol/v1"
+
+	"github.com/status-im/status-go/node"
+
+	gethnode "github.com/ethereum/go-ethereum/node"
+	"github.com/ethereum/go-ethereum/p2p"
+	"github.com/ethereum/go-ethereum/rpc"
+)
+
+var _ gethnode.Service = (*Service)(nil)
+
+type KeysGetter interface {
+	PrivateKey() (*ecdsa.PrivateKey, error)
+}
+
+type Service struct {
+	node     *node.StatusNode
+	keys     KeysGetter
+	protocol protocol.Protocol
+}
+
+func New(node *node.StatusNode, keys KeysGetter) *Service {
+	return &Service{
+		node: node,
+		keys: keys,
+	}
+}
+
+func (s *Service) SetProtocol(proto protocol.Protocol) {
+	s.protocol = proto
+}
+
+// gethnode.Service interface implementation
+
+func (s *Service) Protocols() []p2p.Protocol {
+	return nil
+}
+
+// APIs retrieves the list of RPC descriptors the service provides
+func (s *Service) APIs() []rpc.API {
+	return []rpc.API{
+		{
+			Namespace: "protos",
+			Version:   "1.0",
+			Service:   &PublicAPI{service: s},
+			Public:    true,
+		},
+	}
+}
+
+// Start is called after all services have been constructed and the networking
+// layer was also initialized to spawn any goroutines required by the service.
+func (s *Service) Start(server *p2p.Server) error {
+	return nil
+}
+
+// Stop terminates all goroutines belonging to the service, blocking until they
+// are all terminated.
+func (s *Service) Stop() error {
+	return nil
+}

--- a/protocol/v1/message.go
+++ b/protocol/v1/message.go
@@ -14,8 +14,8 @@ const (
 
 // Message types.
 const (
-	MessageTypePublicGroupUserMessage = "public-group-user-message"
-	MessageTypePrivateUserMessage     = "user-message"
+	MessageTypePublicGroup = "public-group-user-message"
+	MessageTypePrivate     = "user-message"
 )
 
 var (
@@ -26,18 +26,18 @@ var (
 
 // StatusMessageContent contains the chat ID and the actual text of a message.
 type StatusMessageContent struct {
-	ChatID string
-	Text   string
+	ChatID string `json:"chat_id"`
+	Text   string `json:"text"`
 }
 
 // StatusMessage contains all message details.
 type StatusMessage struct {
-	Text      string // TODO: why is this duplicated?
-	ContentT  string
-	MessageT  string
-	Clock     int64 // in milliseconds; see CalcMessageClock for more details
-	Timestamp int64 // in milliseconds
-	Content   StatusMessageContent
+	Text      string               `json:"text"` // TODO: why is this duplicated?
+	ContentT  string               `json:"content_type"`
+	MessageT  string               `json:"message_type"`
+	Clock     int64                `json:"clock"`     // in milliseconds; see CalcMessageClock for more details
+	Timestamp int64                `json:"timestamp"` // in milliseconds
+	Content   StatusMessageContent `json:"content"`
 }
 
 // CreateTextStatusMessage creates a StatusMessage.
@@ -58,12 +58,12 @@ func CreateTextStatusMessage(data []byte, lastClock int64, chatID, messageType s
 
 // CreatePublicTextMessage creates a public text StatusMessage.
 func CreatePublicTextMessage(data []byte, lastClock int64, chatID string) StatusMessage {
-	return CreateTextStatusMessage(data, lastClock, chatID, MessageTypePublicGroupUserMessage)
+	return CreateTextStatusMessage(data, lastClock, chatID, MessageTypePublicGroup)
 }
 
 // CreatePrivateTextMessage creates a public text StatusMessage.
 func CreatePrivateTextMessage(data []byte, lastClock int64, chatID string) StatusMessage {
-	return CreateTextStatusMessage(data, lastClock, chatID, MessageTypePrivateUserMessage)
+	return CreateTextStatusMessage(data, lastClock, chatID, MessageTypePrivate)
 }
 
 // DecodeMessage decodes a raw payload to StatusMessage struct.

--- a/protocol/v1/protocol.go
+++ b/protocol/v1/protocol.go
@@ -25,9 +25,9 @@ type Protocol interface {
 // and some additional fields that we learnt
 // about the message.
 type Message struct {
-	Decoded   StatusMessage
-	SigPubKey *ecdsa.PublicKey
-	Hash      []byte
+	Decoded   StatusMessage    `json:"message"`
+	SigPubKey *ecdsa.PublicKey `json:"-"`
+	Hash      []byte           `json:"hash"`
 }
 
 // RequestOptions is a list of params required
@@ -67,8 +67,8 @@ func DefaultRequestOptions() RequestOptions {
 
 // SubscribeOptions are options for Chat.Subscribe method.
 type SubscribeOptions struct {
-	Identity *ecdsa.PrivateKey // for private chats
-	ChatName string            // for public chats
+	Recipient *ecdsa.PublicKey // for private chats
+	ChatName  string           // for public chats
 }
 
 // Validate vierifies that the given options are valid.
@@ -76,7 +76,7 @@ func (o SubscribeOptions) Validate() error {
 	if o == (SubscribeOptions{}) {
 		return errors.New("empty options")
 	}
-	if o.Identity != nil && o.ChatName != "" {
+	if o.Recipient != nil && o.ChatName != "" {
 		return errors.New("fields Identity and ChatName both set")
 	}
 	return nil
@@ -84,17 +84,12 @@ func (o SubscribeOptions) Validate() error {
 
 // SendOptions are options for Chat.Send.
 type SendOptions struct {
-	Identity *ecdsa.PrivateKey
-
 	ChatName  string           // for public chats
 	Recipient *ecdsa.PublicKey // for private chats
 }
 
 // Validate verifies that the given options are valid.
 func (o SendOptions) Validate() error {
-	if o.Identity == nil {
-		return errors.New("field Identity is required")
-	}
 	if o.ChatName == "" && o.Recipient == nil {
 		return errors.New("field ChatName or Recipient is required")
 	}

--- a/protocol/v1/subscription.go
+++ b/protocol/v1/subscription.go
@@ -17,7 +17,7 @@ func NewSubscription() *Subscription {
 	}
 }
 
-func (s *Subscription) Cancel(err error) {
+func (s *Subscription) cancel(err error) {
 	s.Lock()
 	defer s.Unlock()
 

--- a/protocol/v1/subscription.go
+++ b/protocol/v1/subscription.go
@@ -17,7 +17,7 @@ func NewSubscription() *Subscription {
 	}
 }
 
-func (s *Subscription) cancel(err error) {
+func (s *Subscription) Cancel(err error) {
 	s.Lock()
 	defer s.Unlock()
 
@@ -33,9 +33,11 @@ func (s *Subscription) cancel(err error) {
 func (s *Subscription) Unsubscribe() {
 	s.Lock()
 	defer s.Unlock()
+
 	if s.done == nil {
 		return
 	}
+
 	close(s.done)
 	s.done = nil
 }


### PR DESCRIPTION
This change adds a new RPC service with one API under namespace `protos_` and allows to interact with the status messaging protocol. 

It requires IPC or WebSocket connection to allow all operations.

Testing:
```
# start node
$ make run ARGS="-keyhex=$TEST_PRIVATE_KEY -data-dir=$DATA_DIR"

# Connect via IPC. "messages" is a name of the API method. 
# It subscribes for messages in "status" public channel.
# The first result is a confirmation with a subscription ID.
# The next result is a received message.
$ nc -U $DATA_DIR/geth.ipc
< {"jsonrpc":"2.0","method":"protos_subscribe","params":["messages", {"pubChatName": "status"}],"id":1}
> {"jsonrpc":"2.0","id":1,"result":"0x742359c7d659031a8613c48bc42c7709"}
> {"jsonrpc":"2.0","method":"protos_subscription","params":{"subscription":"0x742359c7d659031a8613c48bc42c7709","result":{"text":"hi","content_type":"text/plain","message_type":"public-group-user-message","clock":155497032596901,"timestamp":1554970325957,"content":{"chat_id":"status","text":"hi"}}}}
```
