### PR TITLE
simplify protocol message struct

### DIFF
--- a/chat.go
+++ b/chat.go
@@ -144,10 +144,10 @@ func (c *ChatViewController) RequestOptions(newest bool) protocol.RequestOptions
 	params := protocol.DefaultRequestOptions()
 
 	if newest && c.lastRequest != (protocol.RequestOptions{}) {
-		params.From = c.lastRequest.To
+		params.From = c.lastRequest.From
 	} else if c.firstRequest != (protocol.RequestOptions{}) {
 		params.From = c.firstRequest.From - defaultRequestOptionsFrom
-		params.To = c.firstRequest.From
+		params.To = c.firstRequest.To
 	}
 
 	return params
@@ -211,8 +211,8 @@ func (c *ChatViewController) writeMessage(message *protocol.Message) error {
 	line := formatMessageLine(
 		pubKey,
 		message.ID,
-		message.Clock,
-		time.Unix(message.Timestamp/1000, 0),
+		int64(message.Clock),
+		message.Timestamp.Time(),
 		message.Text,
 	)
 

--- a/chat_test.go
+++ b/chat_test.go
@@ -73,6 +73,6 @@ func TestSendMessage(t *testing.T) {
 	require.Equal(t, protocol.ContentTypeTextPlain, statusMessage.ContentT)
 	require.Equal(t, protocol.MessageTypePublicGroup, statusMessage.MessageT)
 	require.Equal(t,
-		protocol.StatusMessageContent{ChatID: chatName, Text: string(payload)},
+		protocol.Content{ChatID: chatName, Text: string(payload)},
 		statusMessage.Content)
 }

--- a/main.go
+++ b/main.go
@@ -297,7 +297,7 @@ func main() {
 					Key: gocui.KeyHome,
 					Mod: gocui.ModNone,
 					Handler: func(g *gocui.Gui, v *gocui.View) error {
-						params := chat.RequestOptions(true)
+						params := chat.RequestOptions(false)
 
 						if err := notifications.Debug("Messages request", fmt.Sprintf("%v", params)); err != nil {
 							return err

--- a/protocol/adapters/whisper_client.go
+++ b/protocol/adapters/whisper_client.go
@@ -139,10 +139,8 @@ func (a *WhisperClientAdapter) subscribeMessages(
 					break
 				}
 
-				in <- &protocol.Message{
-					Decoded:   m,
-					SigPubKey: sigPubKey,
-				}
+				m.SigPubKey = sigPubKey
+				in <- &m
 			case err := <-shhSub.Err():
 				sub.Cancel(err)
 				return

--- a/protocol/adapters/whisper_client.go
+++ b/protocol/adapters/whisper_client.go
@@ -138,8 +138,8 @@ func (a *WhisperClientAdapter) subscribeMessages(
 					log.Printf("failed to get a signature: %v", err)
 					break
 				}
-
 				m.SigPubKey = sigPubKey
+
 				in <- &m
 			case err := <-shhSub.Err():
 				sub.Cancel(err)

--- a/protocol/adapters/whisper_service.go
+++ b/protocol/adapters/whisper_service.go
@@ -191,7 +191,7 @@ func (a *WhisperServiceAdapter) handleMessages(received []*whisper.ReceivedMessa
 	}
 
 	sort.Slice(messages, func(i, j int) bool {
-		return messages[i].Decoded.Clock < messages[j].Decoded.Clock
+		return messages[i].Clock < messages[j].Clock
 	})
 
 	return messages
@@ -220,12 +220,10 @@ func (a *WhisperServiceAdapter) decodeMessage(message *whisper.ReceivedMessage) 
 	if err != nil {
 		return nil, err
 	}
+	decoded.ID = hash
+	decoded.SigPubKey = publicKey
 
-	return &protocol.Message{
-		Decoded:   decoded,
-		Hash:      hash,
-		SigPubKey: publicKey,
-	}, nil
+	return &decoded, nil
 }
 
 // Send sends a new message using the Whisper service.

--- a/protocol/client/chat.go
+++ b/protocol/client/chat.go
@@ -147,8 +147,8 @@ func (c *Chat) load(options protocol.RequestOptions) error {
 	// Get already cached messages from the database.
 	cachedMessages, err := c.db.Messages(
 		c.contact,
-		options.FromTime(),
-		options.ToTime(),
+		options.FromAsTime(),
+		options.ToAsTime(),
 	)
 	if err != nil {
 		return errors.Wrap(err, "db failed to get messages")

--- a/protocol/client/chat_test.go
+++ b/protocol/client/chat_test.go
@@ -118,14 +118,12 @@ func TestHandleMessageFromProtocol(t *testing.T) {
 
 	now := time.Now().Unix()
 	message := &protocol.Message{
-		Decoded: protocol.StatusMessage{
-			Text:      "some",
-			ContentT:  protocol.ContentTypeTextPlain,
-			MessageT:  protocol.MessageTypePublicGroup,
-			Timestamp: now * 1000,
-			Clock:     now * 1000,
-		},
-		Hash: []byte{0x01, 0x02, 0x03},
+		ID:        []byte{0x01, 0x02, 0x03},
+		Text:      "some",
+		ContentT:  protocol.ContentTypeTextPlain,
+		MessageT:  protocol.MessageTypePublicGroup,
+		Timestamp: now * 1000,
+		Clock:     now * 1000,
 	}
 	proto.input <- message
 

--- a/protocol/client/chat_test.go
+++ b/protocol/client/chat_test.go
@@ -15,6 +15,10 @@ const (
 	testPubKey = "0x047d036c25b97a377df74ca4f1780369b1f5475cb58b95d8683cce7f7cfd832271072c18ebf75d09b1c04ae066efcf46b10e14bda83fc220b39ae3dece38f91993"
 )
 
+var (
+	timeZero = time.Unix(0, 0)
+)
+
 type message struct {
 	chat string
 	dest *ecdsa.PublicKey
@@ -93,7 +97,7 @@ func TestSendPrivateMessage(t *testing.T) {
 	require.Len(t, chat.Messages(), 1)
 
 	// the message should be also saved in the database
-	result, err := db.Messages(contact, time.Unix(0, 0), time.Now())
+	result, err := db.Messages(contact, timeZero, time.Now())
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 
@@ -134,7 +138,7 @@ func TestHandleMessageFromProtocol(t *testing.T) {
 	require.True(t, chat.HasMessage(message))
 
 	// the message should be also saved in the database
-	result, err := db.Messages(contact, time.Unix(0, 0), now)
+	result, err := db.Messages(contact, timeZero, now)
 	require.NoError(t, err)
 	require.Len(t, result, 1)
 

--- a/protocol/client/contact.go
+++ b/protocol/client/contact.go
@@ -8,18 +8,16 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-type ContactType int
-
 // Types of contacts.
 const (
-	ContactPublicChat ContactType = iota + 1
+	ContactPublicChat int = iota + 1
 	ContactPrivateChat
 )
 
 // Contact is a single contact which has a type and name.
 type Contact struct {
 	Name      string
-	Type      ContactType
+	Type      int
 	PublicKey *ecdsa.PublicKey
 }
 

--- a/protocol/client/database.go
+++ b/protocol/client/database.go
@@ -7,6 +7,7 @@ import (
 	"encoding/gob"
 	"io"
 	"strconv"
+	"time"
 
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
 	"github.com/syndtr/goleveldb/leveldb"
@@ -51,15 +52,16 @@ func NewDatabase(path string) (*Database, error) {
 	return &Database{db: db}, nil
 }
 
+// Close closes the database.
 func (d *Database) Close() error {
 	return d.db.Close()
 }
 
 // Messages returns all messages for a given contact
 // and between from and to timestamps.
-func (d *Database) Messages(c Contact, from, to int64) (result []*protocol.Message, err error) {
+func (d *Database) Messages(c Contact, from, to time.Time) (result []*protocol.Message, err error) {
 	start := d.keyFromContact(c, from, nil)
-	limit := d.keyFromContact(c, to+1, nil) // because iter is right-exclusive
+	limit := d.keyFromContact(c, to.Add(time.Second), nil) // add 1s because iter is right-exclusive
 
 	iter := d.db.NewIterator(&util.Range{Start: start, Limit: limit}, nil)
 	defer iter.Release()
@@ -91,15 +93,12 @@ func (d *Database) SaveMessages(c Contact, messages []*protocol.Message) error {
 
 	batch := new(leveldb.Batch)
 	for _, m := range messages {
-		// TODO(adam): incoming Timestamp is in ms
-		key := d.keyFromContact(c, m.Timestamp/1000, m.ID)
-
 		if err := enc.Encode(m); err != nil {
 			return err
 		}
 
+		key := d.keyFromContact(c, m.Timestamp.Time(), m.ID)
 		data := buf.Bytes()
-
 		// Data from the buffer needs to be copied to another slice
 		// because a slice returned from Buffer.Bytes() is valid
 		// only until another write.
@@ -161,11 +160,11 @@ func (d *Database) prefixFromContact(c Contact) []byte {
 	return h.Sum(nil)
 }
 
-func (d *Database) keyFromContact(c Contact, t int64, hash []byte) []byte {
+func (d *Database) keyFromContact(c Contact, t time.Time, hash []byte) []byte {
 	var key [keyFromContactLength]byte
 
 	copy(key[:], d.prefixFromContact(c))
-	binary.BigEndian.PutUint64(key[contactPrefixLength:], uint64(t))
+	binary.BigEndian.PutUint64(key[contactPrefixLength:], uint64(t.Unix()))
 
 	if hash != nil {
 		copy(key[contactPrefixLength+timeLength:], hash)

--- a/protocol/client/database.go
+++ b/protocol/client/database.go
@@ -92,7 +92,7 @@ func (d *Database) SaveMessages(c Contact, messages []*protocol.Message) error {
 	batch := new(leveldb.Batch)
 	for _, m := range messages {
 		// TODO(adam): incoming Timestamp is in ms
-		key := d.keyFromContact(c, m.Decoded.Timestamp/1000, m.Hash)
+		key := d.keyFromContact(c, m.Timestamp/1000, m.ID)
 
 		if err := enc.Encode(m); err != nil {
 			return err

--- a/protocol/client/messenger.go
+++ b/protocol/client/messenger.go
@@ -75,6 +75,9 @@ LOOP:
 		case ev := <-chat.Events():
 			log.Printf("[Messenger::Join] received an event: %+v", ev)
 			m.events <- ev
+		case <-chat.Done():
+			log.Printf("[Messenger::Join] chat was left")
+			break LOOP
 		case <-cancel:
 			break LOOP
 		}

--- a/protocol/gethservice/api.go
+++ b/protocol/gethservice/api.go
@@ -74,7 +74,7 @@ func (api *PublicAPI) Messages(ctx context.Context, params MessagesParams) (*rpc
 		for {
 			select {
 			case m := <-messages:
-				if err := notifier.Notify(rpcSub.ID, m.Decoded); err != nil {
+				if err := notifier.Notify(rpcSub.ID, m); err != nil {
 					log.Printf("failed to notify %s about new message", rpcSub.ID)
 				}
 			case <-sub.Done():

--- a/protocol/gethservice/api_test.go
+++ b/protocol/gethservice/api_test.go
@@ -100,7 +100,7 @@ func TestPublicAPIMessages(t *testing.T) {
 	require.NoError(t, err)
 	defer func() { go discardStop(aNode) }() // Stop() is slow so do it in a goroutine
 
-	messages := make(chan protocol.StatusMessage)
+	messages := make(chan protocol.Message)
 	params := MessagesParams{
 		ChatParams: ChatParams{
 			PubChatName: "test-chat",

--- a/protocol/gethservice/service.go
+++ b/protocol/gethservice/service.go
@@ -12,6 +12,12 @@ import (
 	"github.com/ethereum/go-ethereum/rpc"
 )
 
+const (
+	// ServiceProtosAPIName is a name of the API namespace
+	// with the protocol specific methods.
+	ServiceProtosAPIName = "protos"
+)
+
 var _ gethnode.Service = (*Service)(nil)
 
 // KeysGetter is an interface that specifies what kind of keys
@@ -51,7 +57,7 @@ func (s *Service) Protocols() []p2p.Protocol {
 func (s *Service) APIs() []rpc.API {
 	return []rpc.API{
 		{
-			Namespace: "protos",
+			Namespace: ServiceProtosAPIName,
 			Version:   "1.0",
 			Service:   &PublicAPI{service: s},
 			Public:    true,

--- a/protocol/v1/clock.go
+++ b/protocol/v1/clock.go
@@ -5,13 +5,13 @@ import "time"
 // CalcMessageClock calculates a new clock value for Message.
 // It is used to properly sort messages and accomodate the fact
 // that time might be different on each device.
-func CalcMessageClock(lastObservedValue, timeInMs int64) int64 {
+func CalcMessageClock(lastObservedValue int64, timeInMs TimestampInMs) int64 {
 	clock := lastObservedValue
-	if clock < timeInMs {
+	if clock < int64(timeInMs) {
 		// Added time should be larger than time skew tollerance for a message.
 		// Here, we use 5 minutes which is much larger
 		// than accepted message time skew by Whisper.
-		clock = timeInMs + int64(5*time.Minute/time.Millisecond)
+		clock = int64(timeInMs) + int64(5*time.Minute/time.Millisecond)
 	} else {
 		clock++
 	}

--- a/protocol/v1/clock.go
+++ b/protocol/v1/clock.go
@@ -2,7 +2,7 @@ package protocol
 
 import "time"
 
-// CalcMessageClock calculates a new clock value for StatusMessage.
+// CalcMessageClock calculates a new clock value for Message.
 // It is used to properly sort messages and accomodate the fact
 // that time might be different on each device.
 func CalcMessageClock(lastObservedValue, timeInMs int64) int64 {

--- a/protocol/v1/decoder.go
+++ b/protocol/v1/decoder.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewMessageDecoder returns a new Transit decoder
-// that can deserialize StatusMessage structs.
+// that can deserialize Message structs.
 // More about Transit: https://github.com/cognitect/transit-format
 func NewMessageDecoder(r io.Reader) *transit.Decoder {
 	decoder := transit.NewDecoder(r)
@@ -29,7 +29,7 @@ func statusMessageHandler(d transit.Decoder, value interface{}) (interface{}, er
 		return nil, errors.New("tagged value does not contain values")
 	}
 
-	sm := StatusMessage{}
+	sm := Message{}
 	for idx, v := range values {
 		var ok bool
 

--- a/protocol/v1/decoder.go
+++ b/protocol/v1/decoder.go
@@ -47,7 +47,11 @@ func statusMessageHandler(d transit.Decoder, value interface{}) (interface{}, er
 		case 3:
 			sm.Clock, ok = v.(int64)
 		case 4:
-			sm.Timestamp, ok = v.(int64)
+			var timestamp int64
+			timestamp, ok = v.(int64)
+			if ok {
+				sm.Timestamp = TimestampInMs(timestamp)
+			}
 		case 5:
 			var content map[interface{}]interface{}
 			content, ok = v.(map[interface{}]interface{})

--- a/protocol/v1/encoder.go
+++ b/protocol/v1/encoder.go
@@ -8,27 +8,27 @@ import (
 )
 
 // NewMessageEncoder returns a new Transit encoder
-// that can encode StatusMessage values.
+// that can encode Message values.
 // More about Transit: https://github.com/cognitect/transit-format
 func NewMessageEncoder(w io.Writer) *transit.Encoder {
 	encoder := transit.NewEncoder(w, false)
-	encoder.AddHandler(statusMessageType, defaultStatusMessageValueEncoder)
+	encoder.AddHandler(messageType, defaultMessageValueEncoder)
 	return encoder
 }
 
 var (
-	statusMessageType                = reflect.TypeOf(StatusMessage{})
-	defaultStatusMessageValueEncoder = &statusMessageValueEncoder{}
+	messageType                = reflect.TypeOf(Message{})
+	defaultMessageValueEncoder = &messageValueEncoder{}
 )
 
-type statusMessageValueEncoder struct{}
+type messageValueEncoder struct{}
 
-func (statusMessageValueEncoder) IsStringable(reflect.Value) bool {
+func (messageValueEncoder) IsStringable(reflect.Value) bool {
 	return false
 }
 
-func (statusMessageValueEncoder) Encode(e transit.Encoder, value reflect.Value, asString bool) error {
-	message := value.Interface().(StatusMessage)
+func (messageValueEncoder) Encode(e transit.Encoder, value reflect.Value, asString bool) error {
+	message := value.Interface().(Message)
 	taggedValue := transit.TaggedValue{
 		Tag: statusMessageTag,
 		Value: []interface{}{

--- a/protocol/v1/message.go
+++ b/protocol/v1/message.go
@@ -43,7 +43,7 @@ func (t TimestampInMs) Time() time.Time {
 
 // TimestampInMsFromTime returns a TimestampInMs from a time.Time instance.
 func TimestampInMsFromTime(t time.Time) TimestampInMs {
-	return TimestampInMs(time.Now().Unix() * 1000)
+	return TimestampInMs(t.UnixNano() / int64(time.Millisecond))
 }
 
 // Message contains all message details.

--- a/protocol/v1/message_test.go
+++ b/protocol/v1/message_test.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -45,4 +46,11 @@ func TestEncodeMessage(t *testing.T) {
 	val, err := DecodeMessage(data)
 	require.NoError(t, err)
 	require.EqualValues(t, testMessageStruct, val)
+}
+
+func TestTimestampInMs(t *testing.T) {
+	ts := TimestampInMs(1555274502548) // random timestamp in milliseconds
+	tt := ts.Time()
+	require.Equal(t, tt.UnixNano(), 1555274502548*int64(time.Millisecond))
+	require.Equal(t, ts, TimestampInMsFromTime(tt))
 }

--- a/protocol/v1/message_test.go
+++ b/protocol/v1/message_test.go
@@ -8,13 +8,13 @@ import (
 
 var (
 	testMessageBytes  = []byte(`["~#c4",["abc123","text/plain","~:public-group-user-message",154593077368201,1545930773682,["^ ","~:chat-id","testing-adamb","~:text","abc123"]]]`)
-	testMessageStruct = StatusMessage{
+	testMessageStruct = Message{
 		Text:      "abc123",
 		ContentT:  "text/plain",
 		MessageT:  "public-group-user-message",
 		Clock:     154593077368201,
 		Timestamp: 1545930773682,
-		Content:   StatusMessageContent{"testing-adamb", "abc123"},
+		Content:   Content{"testing-adamb", "abc123"},
 	}
 )
 

--- a/protocol/v1/protocol.go
+++ b/protocol/v1/protocol.go
@@ -21,15 +21,6 @@ type Protocol interface {
 	Request(ctx context.Context, params RequestOptions) error
 }
 
-// Message contains a decoded message payload
-// and some additional fields that we learnt
-// about the message.
-type Message struct {
-	Decoded   StatusMessage    `json:"message"`
-	SigPubKey *ecdsa.PublicKey `json:"-"`
-	Hash      []byte           `json:"hash"`
-}
-
 // ChatOptions are chat specific options, usually related to the recipient/destination.
 type ChatOptions struct {
 	ChatName  string           // for public chats

--- a/protocol/v1/protocol.go
+++ b/protocol/v1/protocol.go
@@ -32,8 +32,18 @@ type ChatOptions struct {
 type RequestOptions struct {
 	ChatOptions
 	Limit int
-	From  int64
-	To    int64
+	From  int64 // in seconds
+	To    int64 // in seconds
+}
+
+// FromTime converts int64 (timestamp in seconds) to time.Time.
+func (o RequestOptions) FromTime() time.Time {
+	return time.Unix(o.From, 0)
+}
+
+// ToTime converts int64 (timestamp in seconds) to time.Time.
+func (o RequestOptions) ToTime() time.Time {
+	return time.Unix(o.To, 0)
 }
 
 // Validate verifies that the given request options are valid.

--- a/protocol/v1/protocol.go
+++ b/protocol/v1/protocol.go
@@ -36,13 +36,13 @@ type RequestOptions struct {
 	To    int64 // in seconds
 }
 
-// FromTime converts int64 (timestamp in seconds) to time.Time.
-func (o RequestOptions) FromTime() time.Time {
+// FromAsTime converts int64 (timestamp in seconds) to time.Time.
+func (o RequestOptions) FromAsTime() time.Time {
 	return time.Unix(o.From, 0)
 }
 
-// ToTime converts int64 (timestamp in seconds) to time.Time.
-func (o RequestOptions) ToTime() time.Time {
+// ToAsTime converts int64 (timestamp in seconds) to time.Time.
+func (o RequestOptions) ToAsTime() time.Time {
 	return time.Unix(o.To, 0)
 }
 


### PR DESCRIPTION
It replaces the current `protocol.Message` with a simplified and flattened version.