### PR TITLE
Ethereum event.Feed is used for messenger events

### DIFF
--- a/chat_test.go
+++ b/chat_test.go
@@ -64,7 +64,7 @@ func TestSendMessage(t *testing.T) {
 	err = vc.Select(client.Contact{Name: chatName, Type: client.ContactPublicRoom, Topic: chatName})
 	require.NoError(t, err)
 	// close reading loops
-	defer close(vc.cancel)
+	close(vc.cancel)
 
 	err = vc.Send(payload)
 	require.NoError(t, err)

--- a/protocol/client/event.go
+++ b/protocol/client/event.go
@@ -16,6 +16,16 @@ const (
 	EventTypeError
 )
 
+// Event is used to workaround event.Feed type checking.
+// Every event.Feed instance will remember first type that was used either in Send or Subscribe.
+// After that value of every object will be matched against that type.
+// For example if we subscribed first with interface{} - feed.etype will be changed to interface{}
+// and then when client.messageFeed is posted to event.Feed it will get value and match it against interface{}.
+// Feed type checking is either not accurate or it was designed to prevent subscribing with various interfaces.
+type Event struct {
+	Interface interface{}
+}
+
 type EventWithContact interface {
 	GetContact() Contact
 }

--- a/protocol/gethservice/api.go
+++ b/protocol/gethservice/api.go
@@ -189,7 +189,7 @@ func (api *PublicAPI) Chat(ctx context.Context, contact client.Contact) (*rpc.Su
 	// Create a broadcaster instance.
 	// TODO: move it.
 	if api.broadcaster == nil {
-		api.broadcaster = newBroadcaster(api.service.messenger.Events())
+		api.broadcaster = newBroadcaster(api.service.messenger)
 	}
 
 	// Subscription needs to be created


### PR DESCRIPTION
It allows not to block producer when there are not consumers.
And it allows to have more then one consumer in different parts of the application.