### PR TITLE
Message will be saved when processed by stream

### DIFF
--- a/protocol/client/messenger.go
+++ b/protocol/client/messenger.go
@@ -256,13 +256,6 @@ func (m *Messenger) Send(c Contact, data []byte) error {
 	}
 
 	log.Printf("[Messenger::Send] sent message with hash %x", hash)
-
-	message.ID = hash
-	message.SigPubKey = &m.identity.PublicKey
-	_, err = m.db.SaveMessages(c, []*protocol.Message{&message})
-	if err != nil {
-		return errors.Wrap(err, "failed to save the message")
-	}
 	return nil
 }
 


### PR DESCRIPTION
closes: https://github.com/status-im/status-console-client/issues/102

we can ignore on uniqueness conflict but then we won't be able to note that there was such conflict