### PR TITLE
Activate first added chat to avoid crash when sending message

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ Currently the following commands are supported.
 
 ## Adding a public chat
 
-`/contact add <topic>`
+`/chat add <topic>`
 
 ## Adding a contact
 
-`/contact add <public-key> <name>`
+`/chat add <public-key> <name>`
 
 # Packages
 

--- a/binding.go
+++ b/binding.go
@@ -147,7 +147,7 @@ func MoveToNewLineHandler(g *gocui.Gui, v *gocui.View) error {
 	return nil
 }
 
-// GetLineHandler passes the concent of the current line
+// GetLineHandler passes the content of the current line
 // to the provided callback.
 func GetLineHandler(cb func(int, string) error) GocuiHandler {
 	return func(g *gocui.Gui, v *gocui.View) error {

--- a/chat_controller.go
+++ b/chat_controller.go
@@ -153,6 +153,11 @@ func (c *ChatViewController) retrieveMessagesForChat(chat *status.Chat, rConfig 
 	return c.messenger.Retrieve(ctx, *chat, rConfig)
 }
 
+// ActiveChat returns the active chat, if any
+func (c *ChatViewController) ActiveChat() *status.Chat {
+	return c.chat
+}
+
 // Select informs the chat view controller about a selected contact.
 // The chat view controller setup subscribers and request recent messages.
 func (c *ChatViewController) Select(chat *status.Chat) {

--- a/input.go
+++ b/input.go
@@ -76,7 +76,7 @@ func chatAddCmdHandler(args []string) (c *status.Chat, err error) {
 	return
 }
 
-func ChatCmdFactory(c *ChatsViewController) CmdHandler {
+func ChatCmdFactory(chatsvc *ChatsViewController, chatvc *ChatViewController) CmdHandler {
 	return func(b []byte) error {
 		args := bytesToArgs(b)[1:] // remove first item, i.e. "/chat"
 
@@ -88,8 +88,13 @@ func ChatCmdFactory(c *ChatsViewController) CmdHandler {
 			if err != nil {
 				return err
 			}
-			if err := c.Add(chat); err != nil {
+			if err := chatsvc.Add(chat); err != nil {
 				return err
+			}
+
+			// Ensure we have an active chat. This is a quick hack and we should instead do things in an event driven manner.
+			if chatvc.ActiveChat() == nil {
+				chatvc.Select(chat)
 			}
 			// TODO: fix removing chats
 			// case "remove":

--- a/main.go
+++ b/main.go
@@ -314,7 +314,7 @@ func setupGUI(privateKey *ecdsa.PrivateKey, messenger *status.Messenger) error {
 
 	notifications := NewNotificationViewController(&ViewController{vm, g, ViewNotification})
 
-	chat := NewChatViewController(
+	chatVC := NewChatViewController(
 		&ViewController{vm, g, ViewChat},
 		privateKey,
 		messenger,
@@ -323,8 +323,8 @@ func setupGUI(privateKey *ecdsa.PrivateKey, messenger *status.Messenger) error {
 		},
 	)
 
-	chats := NewChatsViewController(&ViewController{vm, g, ViewChats}, messenger)
-	if err := chats.LoadAndRefresh(); err != nil {
+	chatsVC := NewChatsViewController(&ViewController{vm, g, ViewChats}, messenger)
+	if err := chatsVC.LoadAndRefresh(); err != nil {
 		return err
 	}
 
@@ -333,11 +333,11 @@ func setupGUI(privateKey *ecdsa.PrivateKey, messenger *status.Messenger) error {
 		log.Printf("default multiplexer handler")
 		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
-		_, err := chat.Send(ctx, b)
+		_, err := chatVC.Send(ctx, b)
 		return err
 	})
-	inputMultiplexer.AddHandler("/chat", ChatCmdFactory(chats))
-	// inputMultiplexer.AddHandler("/request", RequestCmdFactory(chat))
+	inputMultiplexer.AddHandler("/chat", ChatCmdFactory(chatsVC, chatVC))
+	// inputMultiplexer.AddHandler("/request", RequestCmdFactory(chatVC))
 
 	views := []*View{
 		&View{
@@ -366,7 +366,7 @@ func setupGUI(privateKey *ecdsa.PrivateKey, messenger *status.Messenger) error {
 					Key: gocui.KeyEnter,
 					Mod: gocui.ModNone,
 					Handler: GetLineHandler(func(idx int, _ string) error {
-						selectedChat, ok := chats.ChatByIdx(idx)
+						selectedChat, ok := chatsVC.ChatByIdx(idx)
 						if !ok {
 							return errors.New("chat could not be found")
 						}
@@ -375,7 +375,7 @@ func setupGUI(privateKey *ecdsa.PrivateKey, messenger *status.Messenger) error {
 						// otherwise the main thread is blocked
 						// and nothing is rendered.
 						go func() {
-							chat.Select(selectedChat)
+							chatVC.Select(selectedChat)
 						}()
 
 						return nil


### PR DESCRIPTION
This PR ensures that the first chat added is made active so that a crash doesn't happen when a message is subsequently sent.