### PR TITLE
Make Travis CI build Nimbus version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,4 @@ matrix:
     - make lint
     # fails without -a
     - go test -a ./... # make test
+    - make build-nimbus

--- a/main.go
+++ b/main.go
@@ -89,7 +89,7 @@ func main() {
 	}
 
 	if *useNimbus {
-		if err := startNimbus(privateKey, *listenAddr, *fleet == params.FleetStaging); err != nil {
+		if err := startNimbus(nil, *listenAddr, *fleet == params.FleetStaging); err != nil {
 			exitErr(err)
 		}
 	}


### PR DESCRIPTION
This PR makes Travis CI build also the Nimbus version of the app so we can tell if there's a build regression.